### PR TITLE
Fixed KL bug and changed KL calling convention

### DIFF
--- a/luasrc/dirichlet.lua
+++ b/luasrc/dirichlet.lua
@@ -69,13 +69,13 @@ function distributions.dir.entropy(alpha)
       - cephes.digamma(alpha):cmul(alpha-1):sum()
 end
 
--- returns the KL divergence KL[p || q] betweeen a distribution p with
--- parameters alpha_p and a distribution q with parameters alpha_q
-function distributions.dir.kl(alpha_p, alpha_q)
-  local alpha0_p = alpha_p:sum()
-  local alpha0_q = alpha_q:sum()
-  return cephes.lgam(alpha0_p) - cephes.lgam(alpha0_q)
-      - cephes.lgam(alpha_p):sum() + cephes.lgam(alpha_q):sum()
-      + (alpha0_q - alpha0_p) * cephes.digamma(alpha0_p)
-      + cephes.digamma(alpha_p):cmul(alpha_p - alpha_q):sum()
+-- returns the KL divergence KL[q || p] 
+-- q and p are both tables with field 'alpha', a vector of pseudocounts
+function distributions.dir.kl(q, p)
+  local q0 = q.alpha:sum()
+  local p0 = p.alpha:sum()
+  return cephes.lgam(q0) - cephes.lgam(p0)
+      - cephes.lgam(q.alpha):sum() + cephes.lgam(p.alpha):sum()
+      + (p0 - q0) * cephes.digamma(q0)
+      + cephes.digamma(q.alpha):cmul(q.alpha - p.alpha):sum()
 end

--- a/luasrc/multivariateGaussian.lua
+++ b/luasrc/multivariateGaussian.lua
@@ -328,7 +328,7 @@ function distributions.mvn.kl(q, p)
     end
 
     local function qf(A,x) return torch.dot(x, torch.mv(A,x)) end
-    return (torch.dot(lambda_q, params_p.sigma)
+    return (torch.dot(lambda_p, q.sigma)
         + qf(lambda_p, p.mu - q.mu)
         - ndim
         - distributions.util.logdet(lambda_p)

--- a/luasrc/multivariateGaussian.lua
+++ b/luasrc/multivariateGaussian.lua
@@ -303,34 +303,34 @@ end
 -- KL[p || q], p and q both multivariate normal
 -- Takes two tables, each with field mu and sigma
 -- and optional field lambda for the precision
-function distributions.mvn.kl(params_p, params_q)
-    assert(params_p.mu)
-    assert(params_p.sigma)
+function distributions.mvn.kl(q, p)
+    assert(q.mu)
+    assert(q.sigma)
 
-    assert(params_q.mu)
-    assert(params_q.sigma or params_q.lambda)
+    assert(p.mu)
+    assert(p.sigma or p.lambda)
 
-    local ndim = params_p.mu:size(1)
-    assert(params_p.mu:dim() == 1)
-    assert(distributions.util.isposdef(params_p.sigma))
+    local ndim = q.mu:size(1)
+    assert(q.mu:dim() == 1)
+    assert(distributions.util.isposdef(q.sigma))
 
-    assert(params_q.mu:size(1) == ndim)
-    assert(params_q.mu:dim() == 1)
+    assert(p.mu:size(1) == ndim)
+    assert(p.mu:dim() == 1)
 
-    local lambda_q
-    if params_q.lambda and
-            pcall(distributions.util.isposdef, params_q.lambda) then
-        lambda_q = params_q.lambda
-    elseif pcall(distributions.util.isposdef, params_q.sigma) then
-        lambda_q = torch.inverse(params_q.sigma)
+    local lambda_p
+    if p.lambda and
+            pcall(distributions.util.isposdef, p.lambda) then
+        lambda_p = p.lambda
+    elseif pcall(distributions.util.isposdef, p.sigma) then
+        lambda_p = torch.inverse(p.sigma)
     else
         error("Second argument has neither covriance nor precision")
     end
 
     local function qf(A,x) return torch.dot(x, torch.mv(A,x)) end
     return (torch.dot(lambda_q, params_p.sigma)
-        + qf(lambda_q, params_q.mu - params_p.mu)
+        + qf(lambda_p, p.mu - q.mu)
         - ndim
-        - distributions.util.logdet(lambda_q)
-        - distributions.util.logdet(params_p.sigma)) / 2
+        - distributions.util.logdet(lambda_p)
+        - distributions.util.logdet(q.sigma)) / 2
 end

--- a/luasrc/normalWishart.lua
+++ b/luasrc/normalWishart.lua
@@ -80,13 +80,13 @@ function distributions.nw.entropy(loc, beta, scale, ndof)
       + distributions.wishart.entropy(ndof, scale)
 end
 
-function distributions.nw.kl(params_p, params_q)
-  local ndim = params_p.loc:size(1)
+function distributions.nw.kl(q, p)
+  local ndim = q.loc:size(1)
   local function qf(A, x) return torch.dot(x, torch.mv(A,x)) end
-  return distributions.wishart.kl(params_p, params_q)
-      + (ndim * (math.log(params_p.beta) - math.log(params_q.beta))
-      + ndim * params_q.beta / params_p.beta
+  return distributions.wishart.kl(q, p)
+      + (ndim * (math.log(q.beta) - math.log(p.beta))
+      + ndim * p.beta / q.beta
       - ndim
-      + params_q.beta * params_p.ndof 
-      * qf(params_p.scale, params_q.loc - params_p.loc)) / 2
+      + p.beta * q.ndof 
+      * qf(q.scale, p.loc - q.loc)) / 2
 end

--- a/luasrc/tests/testDirichlet.lua
+++ b/luasrc/tests/testDirichlet.lua
@@ -29,8 +29,8 @@ function myTests.testDirichletKL()
   local alpha_q = torch.Tensor({0.6,0.2,1.5})
   tester:assert(distributions.dir.kl(alpha_p,alpha_q) >= 0)
   tester:assert(distributions.dir.kl(alpha_q,alpha_p) >= 0)
-  tester:asserteq(distributions.dir.kl(alpha_p,alpha_p), 0)
-  tester:asserteq(distributions.dir.kl(alpha_q,alpha_q), 0)
+  tester:assertalmosteq(distributions.dir.kl(alpha_p,alpha_p), 0, 1e-12)
+  tester:assertalmosteq(distributions.dir.kl(alpha_q,alpha_q), 0, 1e-12)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testDirichlet.lua
+++ b/luasrc/tests/testDirichlet.lua
@@ -27,7 +27,10 @@ end
 function myTests.testDirichletKL()
   local alpha_p = torch.Tensor({0.2,1.0,3.0})
   local alpha_q = torch.Tensor({0.6,0.2,1.5})
-  tester:assert(distributions.dir.kl(alpha_p,alpha_q))
+  tester:assert(distributions.dir.kl(alpha_p,alpha_q) >= 0)
+  tester:assert(distributions.dir.kl(alpha_q,alpha_p) >= 0)
+  tester:asserteq(distributions.dir.kl(alpha_p,alpha_p), 0)
+  tester:asserteq(distributions.dir.kl(alpha_q,alpha_q), 0)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testDirichlet.lua
+++ b/luasrc/tests/testDirichlet.lua
@@ -25,12 +25,12 @@ function myTests.testDirichletEntropy()
 end
 
 function myTests.testDirichletKL()
-  local alpha_p = torch.Tensor({0.2,1.0,3.0})
-  local alpha_q = torch.Tensor({0.6,0.2,1.5})
-  tester:assert(distributions.dir.kl(alpha_p,alpha_q) >= 0)
-  tester:assert(distributions.dir.kl(alpha_q,alpha_p) >= 0)
-  tester:assertalmosteq(distributions.dir.kl(alpha_p,alpha_p), 0, 1e-12)
-  tester:assertalmosteq(distributions.dir.kl(alpha_q,alpha_q), 0, 1e-12)
+  local p = {alpha = torch.Tensor({0.2,1.0,3.0})}
+  local q = {alpha = torch.Tensor({0.6,0.2,1.5})}
+  tester:assert(distributions.dir.kl(q,p) >= 0)
+  tester:assert(distributions.dir.kl(p,q) >= 0)
+  tester:assertalmosteq(distributions.dir.kl(p,p), 0, 1e-12)
+  tester:assertalmosteq(distributions.dir.kl(q,q), 0, 1e-12)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testMultivariateGaussian.lua
+++ b/luasrc/tests/testMultivariateGaussian.lua
@@ -742,8 +742,8 @@ function myTests.testMultivariateGaussianKL()
 
     tester:assert(distributions.mvn.kl(p,q) >= 0)
     tester:assert(distributions.mvn.kl(q,p) >= 0)
-    tester:asserteq(distributions.mvn.kl(p,p), 0)
-    tester:asserteq(distributions.mvn.kl(q,q), 0)
+    tester:assertalmosteq(distributions.mvn.kl(p,p), 0, 1e-12)
+    tester:assertalmosteq(distributions.mvn.kl(q,q), 0, 1e-12)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testMultivariateGaussian.lua
+++ b/luasrc/tests/testMultivariateGaussian.lua
@@ -741,6 +741,9 @@ function myTests.testMultivariateGaussianKL()
     q.sigma = q.sigma * q.sigma:t()
 
     tester:assert(distributions.mvn.kl(p,q) >= 0)
+    tester:assert(distributions.mvn.kl(q,p) >= 0)
+    tester:asserteq(distributions.mvn.kl(p,p), 0)
+    tester:asserteq(distributions.mvn.kl(q,q), 0)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testNormalWishart.lua
+++ b/luasrc/tests/testNormalWishart.lua
@@ -65,8 +65,8 @@ function myTests.testNormalWishartKL()
 
   tester:assert(distributions.nw.kl(p,q) >= 0)
   tester:assert(distributions.nw.kl(q,p) >= 0)
-  tester:asserteq(distributions.nw.kl(p,p), 0)
-  tester:asserteq(distributions.nw.kl(q,q), 0)
+  tester:assertalmosteq(distributions.nw.kl(p,p), 0, 1e-12)
+  tester:assertalmosteq(distributions.nw.kl(q,q), 0, 1e-12)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testNormalWishart.lua
+++ b/luasrc/tests/testNormalWishart.lua
@@ -64,6 +64,9 @@ function myTests.testNormalWishartKL()
   q.beta = 5
 
   tester:assert(distributions.nw.kl(p,q) >= 0)
+  tester:assert(distributions.nw.kl(q,p) >= 0)
+  tester:asserteq(distributions.nw.kl(p,p), 0)
+  tester:asserteq(distributions.nw.kl(q,q), 0)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testWishart.lua
+++ b/luasrc/tests/testWishart.lua
@@ -58,6 +58,9 @@ function myTests.testWishartKL()
   q.inverseScale = torch.inverse(q.scale)
   q.scale = nil
   tester:assert(distributions.wishart.kl(p,q) >= 0)
+  tester:assert(distributions.wishart.kl(q,p) >= 0)
+  tester:asserteq(distributions.wishart.kl(p,p), 0)
+  tester:asserteq(distributions.wishart.kl(q,q), 0)
 end
 
 tester:add(myTests)

--- a/luasrc/tests/testWishart.lua
+++ b/luasrc/tests/testWishart.lua
@@ -51,16 +51,16 @@ function myTests.testWishartKL()
   p.scale = p.scale * p.scale:t()
 
   q.scale = torch.randn(D,D)
-  q.scale = torch.randn(D,D)
+  q.scale = q.scale * q.scale:t()
 
   tester:assert(distributions.wishart.kl(p,q) >= 0)
+  tester:assert(distributions.wishart.kl(q,p) >= 0)
+  tester:assertalmosteq(distributions.wishart.kl(p,p), 0, 1e-12)
+  tester:assertalmosteq(distributions.wishart.kl(q,q), 0, 1e-12)
 
   q.inverseScale = torch.inverse(q.scale)
   q.scale = nil
   tester:assert(distributions.wishart.kl(p,q) >= 0)
-  tester:assert(distributions.wishart.kl(q,p) >= 0)
-  tester:asserteq(distributions.wishart.kl(p,p), 0)
-  tester:asserteq(distributions.wishart.kl(q,q), 0)
 end
 
 tester:add(myTests)

--- a/luasrc/wishart.lua
+++ b/luasrc/wishart.lua
@@ -125,45 +125,25 @@ function distributions.wishart.entropy(ndof, scale)
       - (ndof - ndim - 1) * 
           distributions.wishart._elogdet(ndof, ndim, scale) / 2
       + (ndim * ndof) / 2
-
-  -- return cephes.lmvgam(ndof/2, ndim)
-  --     + (ndim + 1) * distributions.util.logdet(scale) / 2
-  --     + ndim * (ndim + 1) * cephes.log(2) / 2
-  --     - (ndof - ndim - 1) 
-  --     * cephes.digamma((-torch.range(1,ndim) + ndof + 1) / 2):sum() / 2
-  --     + ndim * ndof / 2
 end
 
 -- KL divergence between two Wishart distributions
 -- The computation is fastest if we use the scale for
--- p and inverse scale for q, but works if either the
--- field 'scale' or 'inverseScale' is provided with q.
-function distributions.wishart.kl(params_p, params_q)
-  local ndim = params_p.scale:size(1)
-  local ndof_p = params_p.ndof
-  local ndof_q = params_q.ndof
-
-  local scale_p = params_p.scale
-  local invScale_q
-  if params_q.inverseScale then
-    invScale_q = params_q.inverseScale
+-- q and inverse scale for p, but works if either the
+-- field 'scale' or 'inverseScale' is provided with p.
+function distributions.wishart.kl(q, p)
+  local ndim = q.scale:size(1)
+  local invScale_p
+  if p.inverseScale then
+    invScale_p = p.inverseScale
   else
-    invScale_q = torch.inverse(params_q.scale)
+    invScale_p = torch.inverse(p.scale)
   end
 
-  return (ndof_p - ndof_q) * 
-      distributions.wishart._elogdet(ndof_p, ndim, scale_p)
-      - ndof_p * ndim / 2
-      + ndof_p * torch.dot(invScale_q, scale_p)
-      + distributions.wishart._lognorm2(ndof_q, ndim, invScale_q)
-      - distributions.wishart._lognorm(ndof_p, ndim, scale_p)
-
-  -- return (ndof_p - ndof_q) 
-  --     * cephes.digamma((-torch.range(1, ndim) + ndof_p + 1)/2):sum() / 2
-  --     - ndof_q * distributions.util.logdet(scale_p) / 2
-  --     - ndof_q * distributions.util.logdet(invScale_q) / 2
-  --     - ndof_p * ndim / 2
-  --     + ndof_p * torch.dot(invScale_q, scale_p) / 2
-  --     + cephes.lmvgam(ndof_q/2, ndim)
-  --     - cephes.lmvgam(ndof_p/2, ndim)
+  return (q.ndof - p.ndof) * 
+      distributions.wishart._elogdet(q.ndof, ndim, q.scale)
+      - q.ndof * ndim / 2
+      + q.ndof * torch.dot(invScale_p, q.scale) / 2
+      + distributions.wishart._lognorm2(p.ndof, ndim, invScale_p)
+      - distributions.wishart._lognorm(q.ndof, ndim, q.scale)
 end


### PR DESCRIPTION
Fixed issue #33 (missing divide by 2 in one term) and changed calling convention for all KL divergences so that:
1) The arguments are always a pair of tables containing named parameters (this only affectes dir.kl, which previously took two vectors as arguments)
2) The first argument is named q and the second is named p, to be consistent with the conventional notation.