### PR TITLE
Fix bug for Gaussian with near singular covariance matrices

### DIFF
--- a/distributions/multivariateGaussian.lua
+++ b/distributions/multivariateGaussian.lua
@@ -257,7 +257,7 @@ function distributions.mvn.rnd(...)
                     -- Rank-deficient matrix: fall back on SVD
                     local u, s, v = torch.svd(sigma)
                     local tmp = torch.cmul(x, s:sqrt():resize(1, d):expand(n, d))
-                    y = torch.mm(tmp, v)
+                    y = torch.mm(tmp, v:t())
                 end
             end
 

--- a/distributions/tests/testMultivariateGaussian.lua
+++ b/distributions/tests/testMultivariateGaussian.lua
@@ -12,7 +12,7 @@ local function sidakCorrection(alpha, n)
     return 1 - math.pow((1-alpha), 1/n)
 end
 -- This is the significance threshold for the statistical tests, i.e. close to 0
-local statisticalTests = 56
+local statisticalTests = 57
 local alpha = sidakCorrection(.05, statisticalTests)
 
 local standardGaussianPDFWindow = torch.Tensor({
@@ -593,6 +593,40 @@ function myTests.multivariateGaussianRand_Result_D_DD_Standard()
     statisticalTestMultivariateGaussian(result, mu, sigma, true)
 end
 
+function myTests.testMultivariateDegenerateWithGP()
+    -- One of the most useful use cases for a near-singular covariance
+    -- matrix is a Gaussian process evaluated at very close points.
+    -- In particular, the high dimension is very gooda at spotting
+    -- errors in the use of the SVD.
+
+    -- Number of points in the process
+    local D = 500
+    local x = torch.linspace(-10, 10, D)
+    local mean = torch.zeros(D)
+    local cov = torch.zeros(D, D)
+    local sigma = 1.6
+    for i = 1, D do
+        for j = 1, D do
+            local d = x[i] - x[j]
+            cov[i][j] = math.exp(- math.pow(d, 2) / (2*sigma*sigma))
+        end
+    end
+
+    local N = 10000
+    local y = distributions.mvn.rnd(N, mean, cov)
+
+    -- Statistical test on the sum of each trajectory sampled from the GP
+    -- The sums should be distributed iid N(0, cov:sum()).
+    -- If we mess up the transpose in the SVD, we will see a much smaller variance.
+    local sums = y:sum(2)
+    print('sums:size()', sums:size())
+    local p, chi2 = distributions.chi2Gaussian(sums, mean:sum(), math.sqrt(cov:sum()))
+    tester:assert(p >= alpha,
+                  'sums of GP trajectories with a close-to-singular matrix do not'
+                  .. ' have the right distribution. Did you forget a transpose'
+                  .. ' when using the SVD?')
+
+end
 -- NxD, D
 -- D, NxD
 -- NxD, NxD

--- a/distributions/tests/testMultivariateGaussian.lua
+++ b/distributions/tests/testMultivariateGaussian.lua
@@ -619,7 +619,6 @@ function myTests.testMultivariateDegenerateWithGP()
     -- The sums should be distributed iid N(0, cov:sum()).
     -- If we mess up the transpose in the SVD, we will see a much smaller variance.
     local sums = y:sum(2)
-    print('sums:size()', sums:size())
     local p, chi2 = distributions.chi2Gaussian(sums, mean:sum(), math.sqrt(cov:sum()))
     tester:assert(p >= alpha,
                   'sums of GP trajectories with a close-to-singular matrix do not'


### PR DESCRIPTION
Until now, with some (but not all) very-near singular covariance matrices such as occurring in Gaussian Processes, the multivariate Gaussian RNG was completely utterly wrong. This was due to me forgetting a transpose of the result of the SVD when I added support for very-near singular matrices in da73e86525f9ff5f02ecad9ecfc1e930b0a8e409. 

For my (weak) defence, Torch and Numpy have different conventions as to the transpose of the V matrix resulting from the SVD, and I got bitten.

This pull-request adds the missing transpose, and a test on a typical gaussian process example to detect any regression.