### PR TITLE
Fix use of Tester:assert.

### DIFF
--- a/distributions/tests/testNormalWishart.lua
+++ b/distributions/tests/testNormalWishart.lua
@@ -15,7 +15,9 @@ function myTests.testNormalWishartRnd()
   local V = torch.randn(D,D)
   V = V * V:t()
 
-  tester:assert(distributions.nw.rnd(loc, beta, V, nu))
+  local mean, precision = distributions.nw.rnd(loc, beta, V, nu)
+  tester:assert(mean ~= nil)
+  tester:assert(precision ~= nil)
 end
 
 function myTests.testNormalWishartPdf()
@@ -30,8 +32,8 @@ function myTests.testNormalWishartPdf()
   local prec = torch.randn(D,D)
   prec = prec * prec:t()
 
-  tester:assert(distributions.nw.pdf(mean, prec, loc, beta, V, nu))
-  tester:assert(distributions.nw.logpdf(mean, prec, loc, beta, V, nu))
+  tester:assert(distributions.nw.pdf(mean, prec, loc, beta, V, nu) ~= nil)
+  tester:assert(distributions.nw.logpdf(mean, prec, loc, beta, V, nu) ~= nil)
 end
 
 function myTests.testNormalWishartEntropy()
@@ -42,7 +44,7 @@ function myTests.testNormalWishartEntropy()
   local V = torch.randn(D,D)
   V = V * V:t()
 
-  tester:assert(distributions.nw.entropy(loc, beta, V, nu))
+  tester:assert(distributions.nw.entropy(loc, beta, V, nu) ~= nil)
 end
 
 function myTests.testNormalWishartKL()


### PR DESCRIPTION
distributions.nw.rnd actually returns two objects, so (assuming the tests
are checking for not being nil), these need to be individually checked.

I've added "~= nil" to the others for clarity too.