### PR TITLE
Switch from resize to view to deal with non-contiguous input tensors.…

### DIFF
--- a/distributions/normalWishart.lua
+++ b/distributions/normalWishart.lua
@@ -67,7 +67,8 @@ Returns:
 ]]
 function distributions.nw.rnd(loc, beta, scale, ndof)
   local precision = distributions.wishart.rnd(ndof, scale:size(1), scale)
-  local mean = distributions.mvn.rnd(loc, torch.inverse(precision * beta))
+  local mean = distributions.mvn.rnd(loc, torch.inverse(
+                                                 precision * beta):contiguous())
   return mean, precision
 end
 
@@ -87,6 +88,6 @@ function distributions.nw.kl(q, p)
       + (ndim * (math.log(q.beta) - math.log(p.beta))
       + ndim * p.beta / q.beta
       - ndim
-      + p.beta * q.ndof 
+      + p.beta * q.ndof
       * qf(q.scale, p.loc - q.loc)) / 2
 end


### PR DESCRIPTION
… This change will cause an error in the case when the input provided by the user is non-contiguous.